### PR TITLE
Remove bogus extra double quote in run-peers.sh

### DIFF
--- a/resources/leiningen/new/onyx_app/run-peers.sh
+++ b/resources/leiningen/new/onyx_app/run-peers.sh
@@ -7,4 +7,4 @@ echo "Setting shared memory for Aeron"
 mount -t tmpfs -o remount,rw,nosuid,nodev,noexec,relatime,size=256M tmpfs /dev/shm
 APP_NAME=$(echo "{{app-name}}" | sed s/"-"/"_"/g)
 java -cp /srv/{{app-name}}.jar "$APP_NAME.launcher.aeron_media_driver" &
-java -cp /srv/{{app-name}}.jar "$APP_NAME".launcher.launch_prod_peers" $ONYX_ID $NPEERS
+java -cp /srv/{{app-name}}.jar "$APP_NAME.launcher.launch_prod_peers" $ONYX_ID $NPEERS


### PR DESCRIPTION
This didn't look right; but I think I fixed it :)
