### PR TITLE
Switch to official java:8-jre-alpine image in Dockerfile

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject onyx-app/lein-template "0.9.0.8"
+(defproject onyx-app/lein-template "0.9.0.9-SNAPSHOT"
   :description "Onyx Leiningen application template"
   :url "https://github.com/onyx-platform/onyx-template"
   :license {:name "Eclipse Public License"

--- a/src/leiningen/new/onyx_app/Dockerfile
+++ b/src/leiningen/new/onyx_app/Dockerfile
@@ -1,4 +1,4 @@
-FROM anapsix/alpine-java:jre8
+FROM java:8-jre-alpine
 MAINTAINER Gardner Vickers <gardner@vickers.me>
 
 ADD https://github.com/just-containers/s6-overlay/releases/download/v1.11.0.1/s6-overlay-amd64.tar.gz /tmp/

--- a/src/leiningen/new/onyx_app/scripts/run_media_driver.sh
+++ b/src/leiningen/new/onyx_app/scripts/run_media_driver.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-/opt/jdk/bin/java -cp /opt/peer.jar "lib_onyx.media_driver"
+/usr/bin/java -cp /opt/peer.jar "lib_onyx.media_driver"

--- a/src/leiningen/new/onyx_app/scripts/run_peer.sh
+++ b/src/leiningen/new/onyx_app/scripts/run_peer.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-/opt/jdk/bin/java -cp /opt/peer.jar {{app-name-underscore}}.core start-peers "$NPEERS" -p :docker
+/usr/bin/java -cp /opt/peer.jar {{app-name-underscore}}.core start-peers "$NPEERS" -p :docker


### PR DESCRIPTION
Wasn't sure if I should PR against `master` or the default `0.9.x`. Let me know if you want me to redo this against `master`.
