### PR TITLE
Curl -> Tar of remote repo

### DIFF
--- a/src/leiningen/new/onyx_app/Dockerfile
+++ b/src/leiningen/new/onyx_app/Dockerfile
@@ -1,14 +1,13 @@
-FROM frolvlad/alpine-oraclejdk8:full
+FROM frolvlad/alpine-oraclejre8:slim
 MAINTAINER Gardner Vickers <gardner@vickers.me>
 
-ADD https://github.com/just-containers/s6-overlay/releases/download/v1.11.0.1/s6-overlay-amd64.tar.gz /tmp/
+RUN apk add --update libgcc libstdc++ bash curl
+RUN cd /tmp && curl -sL https://github.com/just-containers/s6-overlay/releases/download/v1.11.0.1/s6-overlay-amd64.tar.gz  | tar xz
+RUN cd /
 
 RUN cp -r /tmp/etc/* /etc
 RUN cp -r /tmp/usr/* /usr
 RUN mv /tmp/init /
-
-RUN tar xzf /tmp/s6-overlay-amd64.tar.gz -C /
-RUN apk add --update libgcc libstdc++ bash
 
 ADD scripts/run_media_driver.sh /etc/services.d/media_driver/run
 ADD scripts/finish_media_driver.sh /etc/s6/media_driver/finish


### PR DESCRIPTION
When running these commands - 
```
lein new onyx-app example -- +docker
cd example && lein do clean, uberjar; docker build -t peerimage .
```

I am getting an error - 
`cp: can't stat '/tmp/etc/*': No such file or directory`

I think this change ([# 72](https://github.com/onyx-platform/onyx-template/issues/72)) needs to be tweaked a bit, as Docker does not decompress `tar` files with `ADD` when referencing a remote URL (cf. [#2369](https://github.com/moby/moby/issues/2369))

So, instead, this PR adds `curl` and pipes it directly to `tar`, which will keep the archive file off the image. I also switched from the `jdk:full` image to `jre:slim`, which should knock off 80 mb or so. 